### PR TITLE
Fix bio onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ backend_mm/__pycache__/
 backend_mm/venv/**
 frontend_mm/package-lock.json
 
-.venv
+*/.venv

--- a/backend_mm/user.py
+++ b/backend_mm/user.py
@@ -143,7 +143,7 @@ class UserAPI(MethodView):
         career = request.form.get('career')
         education = request.form.get('education')
         photo = request.form.get('photo')
-        bio = request.form.get('bio')
+        bio = request.form.get('about')
         update_query = "UPDATE user SET attr_age = %s, attr_gender = %s, attr_career = %s, attr_education = %s, imageURL = %s, bio = %s WHERE id = %s"
         user_data = (age, gender, career, education, photo, bio, user_id)
         

--- a/backend_mm/user.py
+++ b/backend_mm/user.py
@@ -143,7 +143,7 @@ class UserAPI(MethodView):
         career = request.form.get('career')
         education = request.form.get('education')
         photo = request.form.get('photo')
-        bio = request.form.get('about')
+        bio = request.form.get('bio')
         update_query = "UPDATE user SET attr_age = %s, attr_gender = %s, attr_career = %s, attr_education = %s, imageURL = %s, bio = %s WHERE id = %s"
         user_data = (age, gender, career, education, photo, bio, user_id)
         

--- a/frontend_mm/src/pages/OnBoarding.jsx
+++ b/frontend_mm/src/pages/OnBoarding.jsx
@@ -28,7 +28,7 @@ const OnBoarding = () => {
         degree: '',
         salary: '',
         url: '',
-        about: ''
+        bio: '',
     });
 
     const [ageValidation, setAgeValidation] = useState({
@@ -64,6 +64,7 @@ const OnBoarding = () => {
         formDataToSend.append('career', formData.salary);
         formDataToSend.append('education', formData.degree);
         formDataToSend.append('photo', formData.url);
+        formDataToSend.append('bio', formData.bio);
 
         // Make the POST request
         try {
@@ -204,14 +205,14 @@ const OnBoarding = () => {
                             </option>
                         ))}
                     </select>
-                    <label htmlFor="about">About me</label>
+                    <label htmlFor="bio">About me</label>
                     <input
-                        id="about"
+                        id="bio"
                         type="text"
-                        name="about"
+                        name="bio"
                         required={true}
                         placeholder="I like long walks.."
-                        value={formData.about}
+                        value={formData.bio}
                         onChange={handleChange}
                     />
                     <input type="submit"/>


### PR DESCRIPTION
Previously, could not save bio when Onboarding from the MixnMatch frontend due to the field being called "about" in the frontend and "bio" in the backend.
"bio" was chosen as it is what our POST request sends on UnHinged when creating a new bot